### PR TITLE
Implement LocalStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "bingo-builder",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.3",
+      "version": "2.0.0",
       "dependencies": {
         "@material-ui/core": "^4.12.4",
+        "@material-ui/icons": "^4.11.3",
         "@material-ui/styles": "^4.11.5",
         "jspdf": "^2.5.1",
         "react": "^17.0.2",
@@ -500,6 +501,28 @@
         "url": "https://opencollective.com/material-ui"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@material-ui/icons": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
+      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.0.0",
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -2305,6 +2328,14 @@
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0",
         "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
+      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "bingo-builder",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@material-ui/core": "^4.12.4",
         "jspdf": "^2.5.1",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/react": "^17.0.44",
         "@types/react-dom": "^17.0.15",
-        "@vitejs/plugin-react-refresh": "^1.3.6",
+        "@vitejs/plugin-react": "^1.3.1",
         "typescript": "^4.6.3",
         "vite": "^2.9.5"
       },
@@ -96,6 +96,18 @@
         "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -188,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -278,13 +290,62 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.14.5.tgz",
-      "integrity": "sha512-M/fmDX6n0cfHK/NLTcPmrfVAORKDhK8tyjDhyxlUjYyPYYO8FRWwuxBA3WBx8kWN/uBUuwGa3s/0+hQ9JIN3Tg==",
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+      "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+      "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.16.7",
+        "@babel/types": "^7.17.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
+      "integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.16.7.tgz",
+      "integrity": "sha512-oe5VuWs7J9ilH3BCCApGoYjHoSO48vkjX2CbA5bFVhIuO2HKxA3vyF7rleA4o6/4rTDbk6r8hBW7Ul8E+UZrpA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -294,12 +355,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.14.5.tgz",
-      "integrity": "sha512-1TpSDnD9XR/rQ2tzunBVPThF5poaYT9GqP+of8fAtguYuI/dm2RkrMBDemsxtY0XBzvW7nXjYM0hRyKX9QYj7Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.16.7.tgz",
+      "integrity": "sha512-rONFiQz9vgbsnaMtQlZCjIRwhJvlrPET8TabIUK2hzlXw9B9s2Ieaxte1SCOOXMbWRHodbKixNf3BLcWVOQ8Bw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -610,20 +671,32 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
-    "node_modules/@vitejs/plugin-react-refresh": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-refresh/-/plugin-react-refresh-1.3.6.tgz",
-      "integrity": "sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==",
+    "node_modules/@vitejs/plugin-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.1.tgz",
+      "integrity": "sha512-qQS8Y2fZCjo5YmDUplEXl3yn+aueiwxB7BaoQ4nWYJYR+Ai8NXPVLlkLobVMs5+DeyFyg9Lrz6zCzdX1opcvyw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.8",
-        "@babel/plugin-transform-react-jsx-self": "^7.14.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@rollup/pluginutils": "^4.1.1",
-        "react-refresh": "^0.10.0"
+        "@babel/core": "^7.17.9",
+        "@babel/plugin-transform-react-jsx": "^7.17.3",
+        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+        "@rollup/pluginutils": "^4.2.0",
+        "react-refresh": "^0.12.0",
+        "resolve": "^1.22.0"
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.12.0.tgz",
+      "integrity": "sha512-suLIhrU2IHKL5JEKR/fAwJv7bbeq4kJ+pJopf77jHwuR+HmJS/HbrPIGsTBUVfw7tXPOmYv7UJ7PCaN49e8x4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -1639,15 +1712,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-refresh": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
-      "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -1936,6 +2000,15 @@
         "source-map": "^0.5.0"
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
     "@babel/helper-compilation-targets": {
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
@@ -2002,9 +2075,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true
     },
     "@babel/helper-simple-access": {
@@ -2065,22 +2138,53 @@
       "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==",
       "dev": true
     },
-    "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.14.5.tgz",
-      "integrity": "sha512-M/fmDX6n0cfHK/NLTcPmrfVAORKDhK8tyjDhyxlUjYyPYYO8FRWwuxBA3WBx8kWN/uBUuwGa3s/0+hQ9JIN3Tg==",
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+      "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+      "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.16.7",
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
+      "integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.16.7"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.16.7.tgz",
+      "integrity": "sha512-oe5VuWs7J9ilH3BCCApGoYjHoSO48vkjX2CbA5bFVhIuO2HKxA3vyF7rleA4o6/4rTDbk6r8hBW7Ul8E+UZrpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.14.5.tgz",
-      "integrity": "sha512-1TpSDnD9XR/rQ2tzunBVPThF5poaYT9GqP+of8fAtguYuI/dm2RkrMBDemsxtY0XBzvW7nXjYM0hRyKX9QYj7Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.16.7.tgz",
+      "integrity": "sha512-rONFiQz9vgbsnaMtQlZCjIRwhJvlrPET8TabIUK2hzlXw9B9s2Ieaxte1SCOOXMbWRHodbKixNf3BLcWVOQ8Bw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/runtime": {
@@ -2303,17 +2407,28 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
-    "@vitejs/plugin-react-refresh": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-refresh/-/plugin-react-refresh-1.3.6.tgz",
-      "integrity": "sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==",
+    "@vitejs/plugin-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.1.tgz",
+      "integrity": "sha512-qQS8Y2fZCjo5YmDUplEXl3yn+aueiwxB7BaoQ4nWYJYR+Ai8NXPVLlkLobVMs5+DeyFyg9Lrz6zCzdX1opcvyw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.14.8",
-        "@babel/plugin-transform-react-jsx-self": "^7.14.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@rollup/pluginutils": "^4.1.1",
-        "react-refresh": "^0.10.0"
+        "@babel/core": "^7.17.9",
+        "@babel/plugin-transform-react-jsx": "^7.17.3",
+        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+        "@rollup/pluginutils": "^4.2.0",
+        "react-refresh": "^0.12.0",
+        "resolve": "^1.22.0"
+      },
+      "dependencies": {
+        "react-refresh": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.12.0.tgz",
+          "integrity": "sha512-suLIhrU2IHKL5JEKR/fAwJv7bbeq4kJ+pJopf77jHwuR+HmJS/HbrPIGsTBUVfw7tXPOmYv7UJ7PCaN49e8x4A==",
+          "dev": true
+        }
       }
     },
     "ansi-styles": {
@@ -2988,12 +3103,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-refresh": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
-      "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
-      "dev": true
     },
     "react-transition-group": {
       "version": "4.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,17 @@
       "version": "1.1.3",
       "dependencies": {
         "@material-ui/core": "^4.12.4",
+        "@material-ui/styles": "^4.11.5",
         "jspdf": "^2.5.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "recoil": "^0.7.2"
+        "recoil": "^0.7.2",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/react": "^17.0.44",
         "@types/react-dom": "^17.0.15",
+        "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^1.3.1",
         "typescript": "^4.6.3",
         "vite": "^2.9.5"
@@ -670,6 +673,12 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "1.3.1",
@@ -1903,6 +1912,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.5.tgz",
@@ -2406,6 +2423,12 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@vitejs/plugin-react": {
       "version": "1.3.1",
@@ -3230,6 +3253,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vite": {
       "version": "2.9.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
     "@material-ui/styles": "^4.11.5",
     "jspdf": "^2.5.1",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "serve": "vite preview"
   },
   "dependencies": {
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^17.0.44",
     "@types/react-dom": "^17.0.15",
-    "@vitejs/plugin-react-refresh": "^1.3.6",
+    "@vitejs/plugin-react": "^1.3.1",
     "typescript": "^4.6.3",
     "vite": "^2.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "2.0.0",
   "engines": {
     "node": ">=14"
   },

--- a/package.json
+++ b/package.json
@@ -10,14 +10,17 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.4",
+    "@material-ui/styles": "^4.11.5",
     "jspdf": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "recoil": "^0.7.2"
+    "recoil": "^0.7.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.44",
     "@types/react-dom": "^17.0.15",
+    "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^1.3.1",
     "typescript": "^4.6.3",
     "vite": "^2.9.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment, useEffect, useState } from 'react'
+import { AppBar, Toolbar, Typography } from '@material-ui/core';
+import { LineAndStyle, LineAndStyleByDifficulty, LinesByDifficulty } from './types'
+import { FreeSpaceSetting, InputStepOutput, Settings } from './types'
 import InputStep from './steps/InputStep'
 import RenderStep from './steps/RenderStep'
 import OutputStep from './steps/OutputStep'
-import './App.css'
-import { LineAndStyle, LineAndStyleByDifficulty, LinesByDifficulty } from './types'
-import { FreeSpaceSetting, InputStepOutput, Settings } from './types'
 import packageJson from '../package.json'
+import './App.css'
 
 enum Step {
   input,
@@ -66,7 +67,14 @@ function App() {
     document.title = `Bingo Builder v${packageJson.version}`;
   }, [])
 
-  return getStepContent();
+  return (<Fragment>
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6">Bingo Builder</Typography>
+      </Toolbar>
+    </AppBar>
+    {getStepContent()}
+  </Fragment>)
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,16 @@
 import React, { Fragment, useEffect, useState } from 'react'
-import { AppBar, Toolbar, Typography } from '@material-ui/core';
-import { LineAndStyle, LineAndStyleByDifficulty, LinesByDifficulty } from './types'
-import { FreeSpaceSetting, InputStepOutput, Settings } from './types'
+import { useRecoilState } from 'recoil'
+import { LineAndStyle, LineAndStyleByDifficulty, LinesByDifficulty, FreeSpaceSetting, InputStepOutput, Settings, AppStep } from './types'
 import InputStep from './steps/InputStep'
 import RenderStep from './steps/RenderStep'
 import OutputStep from './steps/OutputStep'
+import TopAppBar from './components/TopAppBar';
 import packageJson from '../package.json'
-import './App.css'
-
-enum Step {
-  input,
-  render,
-  output
-}
+import ProjectList from './steps/ProjectList'
+import { appStepState } from './store/appState';
 
 function App() {
-  const [step, setStep] = useState(Step.input);
+  const [step, setStep] = useRecoilState(appStepState);
   const [linesToRender, setLinesToRender] = useState({
     easy: [],
     medium: [],
@@ -36,7 +31,7 @@ function App() {
   const onInputStepComplete = (output: InputStepOutput) => {
     setLinesToRender(output.lines);
     setSettings(output.settings);
-    setStep(Step.render);
+    setStep(AppStep.render);
   }
 
   const onRenderStepComplete = (linesAndStyles: {
@@ -45,18 +40,21 @@ function App() {
     hard: LineAndStyle[]
   }) => {
     setLinesAndStyles(linesAndStyles)
-    setStep(Step.output);
+    setStep(AppStep.output);
   }
 
   const getStepContent = () => {
     switch(step) {
-      case Step.input: {
+      case AppStep.projectList: {
+        return <ProjectList />
+      }
+      case AppStep.input: {
         return <InputStep onComplete={onInputStepComplete} />;
       }
-      case Step.render: {
+      case AppStep.render: {
         return <RenderStep linesToRender={linesToRender} onComplete={onRenderStepComplete} />
       }
-      case Step.output: {
+      case AppStep.output: {
         return <OutputStep linesAndStyles={linesAndStyles} settings={settings} />
       }
       default: return null
@@ -68,11 +66,7 @@ function App() {
   }, [])
 
   return (<Fragment>
-    <AppBar position="static">
-      <Toolbar>
-        <Typography variant="h6">Bingo Builder</Typography>
-      </Toolbar>
-    </AppBar>
+    <TopAppBar />
     {getStepContent()}
   </Fragment>)
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react'
 import { useRecoilState } from 'recoil'
-import { LineAndStyle, LineAndStyleByDifficulty, LinesByDifficulty, FreeSpaceSetting, InputStepOutput, Settings, AppStep } from './types'
+import { LineAndStyle, LineAndStyleByDifficulty, FreeSpaceSetting, Settings, AppStep } from './types'
 import InputStep from './steps/InputStep'
 import RenderStep from './steps/RenderStep'
 import OutputStep from './steps/OutputStep'
@@ -11,12 +11,7 @@ import { appStepState } from './store/appState';
 
 function App() {
   const [step, setStep] = useRecoilState(appStepState);
-  const [linesToRender, setLinesToRender] = useState({
-    easy: [],
-    medium: [],
-    hard: []
-  } as LinesByDifficulty);
-  const [settings, setSettings] = useState({
+  const [settings] = useState({
     freeSpace: FreeSpaceSetting.none,
     easy: 0,
     medium: 0,
@@ -27,12 +22,6 @@ function App() {
     medium: [],
     hard: []
   } as LineAndStyleByDifficulty);
-
-  const onInputStepComplete = (output: InputStepOutput) => {
-    setLinesToRender(output.lines);
-    setSettings(output.settings);
-    setStep(AppStep.render);
-  }
 
   const onRenderStepComplete = (linesAndStyles: {
     easy: LineAndStyle[],
@@ -49,10 +38,10 @@ function App() {
         return <ProjectList />
       }
       case AppStep.input: {
-        return <InputStep onComplete={onInputStepComplete} />;
+        return <InputStep />;
       }
       case AppStep.render: {
-        return <RenderStep linesToRender={linesToRender} onComplete={onRenderStepComplete} />
+        return <RenderStep onComplete={onRenderStepComplete} />
       }
       case AppStep.output: {
         return <OutputStep linesAndStyles={linesAndStyles} settings={settings} />

--- a/src/appTheme.tsx
+++ b/src/appTheme.tsx
@@ -1,0 +1,20 @@
+import { createTheme } from "@material-ui/core/styles";
+
+const appTheme = createTheme({
+  palette: {
+    primary: {
+      light: '#c158dc',
+      main: '#8e24aa',
+      dark: '#5c007a',
+      contrastText: '#fff'
+    },
+    secondary: {
+      light: '#6effff',
+      main: '#00e5ff',
+      dark: '#00b2cc',
+      contrastText: '#000000'
+    }
+  }
+})
+
+export default appTheme;

--- a/src/components/BingoInput.tsx
+++ b/src/components/BingoInput.tsx
@@ -3,8 +3,8 @@ import { Box, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles'
 
 type Props = {
-  onChange: (lines: string) => void,
-  lines: string,
+  onChange: (lines: string[]) => void,
+  lines: string[],
   label: string
 }
 
@@ -23,11 +23,11 @@ export default function BingoInput({
 }: Props) {
   const textFieldStyles = useTextFieldStyles();
 
-  const getNumLines = () => lines.split(/[\n\r]/g).map(line => line.trim()).length
-  const getNumLinesTrimmed = () => lines.split(/[\n\r]/g).map(line => line.trim()).filter(l => l).length
+  const getNumLines = () => lines.map(line => line.trim()).length
+  const getNumLinesTrimmed = () => lines.map(line => line.trim()).filter(l => l).length
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(e.target.value);
+    onChange(e.target.value.split(/[\n\r]/g));
   }
 
   return (
@@ -36,7 +36,7 @@ export default function BingoInput({
         label={`${label} Bingo Lines (${getNumLinesTrimmed()})`}
         multiline
         minRows={getNumLines()}
-        value={lines}
+        value={lines.join('\r')}
         onChange={handleOnChange}
         fullWidth
         InputProps={{

--- a/src/components/BingoInput.tsx
+++ b/src/components/BingoInput.tsx
@@ -35,7 +35,7 @@ export default function BingoInput({
       <TextField
         label={`${label} Bingo Lines (${getNumLinesTrimmed()})`}
         multiline
-        rows={getNumLines()}
+        minRows={getNumLines()}
         value={lines}
         onChange={handleOnChange}
         fullWidth

--- a/src/components/News.tsx
+++ b/src/components/News.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTheme } from '@material-ui/core/styles';
+import { Dialog, DialogTitle, DialogContent, Typography, useMediaQuery, IconButton } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+
+type Props = {
+  open: boolean;
+  onClose: () => any;
+}
+
+export default function News({ open, onClose }: Props) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <Dialog fullScreen={fullScreen} open={open} onClose={onClose}>
+      <DialogTitle disableTypography style={{
+        borderBottom: `1px solid ${theme.palette.grey[300]}`
+      }}>
+        <Typography variant="h6">What's New</Typography>
+        <IconButton onClick={onClose} aria-label="Close" color="inherit" style={{
+          position: 'absolute',
+          right: theme.spacing(1),
+          top: theme.spacing(1),
+        }}><CloseIcon /></IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <h3>Version 2.0.0</h3>
+        <p>With this version of Bingo Builder, you can now save projects in your local browser, using standard LocalStorage.</p>
+        <p>This means that every change you make to a project will now be saved automatically, and you can create as many projects as your browser storage will allow.</p>
+        <p>Errors are generally handled, but they aren't exposed to the user yet, so please check the developer tools console if you think you're having an error.</p>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
-import { AppBar, Toolbar, Typography, FormControlLabel, Checkbox } from '@material-ui/core';
-import { useStorageSettingState } from '../store/appState';
-import { useRecoilState } from 'recoil';
+import { AppBar, Button, Divider, Toolbar, Typography, FormControlLabel, Checkbox } from '@material-ui/core';
+import { appStepState, useStorageSettingState } from '../store/appState';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { AppStep } from '../types';
+import { loadedProjectState } from '../store/project';
 
 export default function TopAppBar() {
   const [useStorageSettingValue, setUseStorageSetting] = useRecoilState(useStorageSettingState);
+  const [appStep, setAppStepState] = useRecoilState(appStepState);
+  const setLoadedProjectState = useSetRecoilState(loadedProjectState);
+
+  const onProjectsButtonClicked = () => {
+    if( appStep !== AppStep.projectList ) {
+      setLoadedProjectState(null);
+      setAppStepState(AppStep.projectList);
+    }
+  }
+
   return (
     <AppBar position="static">
       <Toolbar>
         <Typography variant="h6">Bingo Builder</Typography>
+        <Divider orientation="vertical" flexItem style={{ marginLeft: '1em', marginRight: '1em' }} />
+        <Button onClick={onProjectsButtonClicked} color="inherit">Projects</Button>
         <FormControlLabel
           control={
             <Checkbox
@@ -17,6 +31,9 @@ export default function TopAppBar() {
               name="useStorageSetting"
             />
           }
+          style={{
+            marginLeft: 'auto'
+          }}
           label="Use Storage"
         />
       </Toolbar>

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { AppBar, Button, Divider, Toolbar, Typography, CircularProgress } from '@material-ui/core';
+import { AppBar, Button, Divider, Toolbar, Typography, CircularProgress, useMediaQuery, IconButton } from '@material-ui/core';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import { useTheme } from '@material-ui/core/styles';
 import { appStepState, saveInProgressState } from '../store/appState';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -13,6 +14,7 @@ export default function TopAppBar() {
   const [loadedProject, setLoadedProjectState] = useRecoilState(loadedProjectState);
   const saveInProgress = useRecoilValue(saveInProgressState);
   const [showNews, setShowNews] = useState(false);
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const onProjectsButtonClicked = () => {
     if( appStep !== AppStep.projectList ) {
@@ -37,6 +39,13 @@ export default function TopAppBar() {
     )
   }
 
+  const NewsButton = () => {
+    if( isSmall )
+      return <IconButton color="inherit" style={{marginLeft: "auto" }} onClick={() => setShowNews(true)}><HelpOutlineIcon /></IconButton>
+    else
+      return <Button color="inherit" style={{marginLeft: "auto" }} onClick={() => setShowNews(true)}>What's new <HelpOutlineIcon style={{marginLeft: '0.5em' }}/></Button>
+  }
+
   return (
     <AppBar position="static">
       <Toolbar>
@@ -53,7 +62,7 @@ export default function TopAppBar() {
         >Projects</Button>
         {loadedProject ? <Typography style={{ marginLeft: '0.5em', marginRight: '0.5em' }}>/</Typography> : null}
         <LoadedProjectLink />
-        <Button color="inherit" style={{marginLeft: "auto" }} onClick={() => setShowNews(true)}>What's new</Button>
+        <NewsButton />
         <News open={showNews} onClose={() => setShowNews(false)} />
       </Toolbar>
     </AppBar>

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { AppBar, Button, Divider, Toolbar, Typography, FormControlLabel, Checkbox, CircularProgress } from '@material-ui/core';
-import { appStepState, saveInProgressState, useStorageSettingState } from '../store/appState';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { AppBar, Button, Divider, Toolbar, Typography, CircularProgress } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import { appStepState, saveInProgressState } from '../store/appState';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { AppStep } from '../types';
 import { loadedProjectState } from '../store/project';
 
 export default function TopAppBar() {
-  const [useStorageSettingValue, setUseStorageSetting] = useRecoilState(useStorageSettingState);
+  const theme = useTheme();
   const [appStep, setAppStepState] = useRecoilState(appStepState);
-  const setLoadedProjectState = useSetRecoilState(loadedProjectState);
+  const [loadedProject, setLoadedProjectState] = useRecoilState(loadedProjectState);
   const saveInProgress = useRecoilValue(saveInProgressState);
 
   const onProjectsButtonClicked = () => {
@@ -18,26 +19,38 @@ export default function TopAppBar() {
     }
   }
 
+  const LoadedProjectLink = () => {
+    if( !loadedProject ) return null;
+    return (
+      <Button
+        disabled={saveInProgress}
+        onClick={() => setAppStepState(AppStep.input)}
+        color="inherit"
+        style={{
+          backgroundColor: theme.palette.primary.dark
+        }}
+      >
+        {loadedProject.id}
+      </Button>
+    )
+  }
+
   return (
     <AppBar position="static">
       <Toolbar>
         <Typography variant="h6">Bingo Builder</Typography>
         <Divider orientation="vertical" flexItem style={{ marginLeft: '1em', marginRight: '1em' }} />
         { saveInProgress ? <CircularProgress size="1em" color="inherit" /> : null}
-        <Button disabled={saveInProgress} onClick={onProjectsButtonClicked} color="inherit">Projects</Button>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={useStorageSettingValue}
-              onChange={ e => setUseStorageSetting(e.target.checked)}
-              name="useStorageSetting"
-            />
-          }
+        <Button 
+          disabled={saveInProgress} 
+          onClick={onProjectsButtonClicked} 
+          color="inherit"
           style={{
-            marginLeft: 'auto'
+            backgroundColor: appStep === AppStep.projectList ? theme.palette.primary.dark : undefined
           }}
-          label="Use Storage"
-        />
+        >Projects</Button>
+        {loadedProject ? <Typography style={{ marginLeft: '0.5em', marginRight: '0.5em' }}>/</Typography> : null}
+        <LoadedProjectLink />
       </Toolbar>
     </AppBar>
   );

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { AppBar, Button, Divider, Toolbar, Typography, FormControlLabel, Checkbox } from '@material-ui/core';
-import { appStepState, useStorageSettingState } from '../store/appState';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { AppBar, Button, Divider, Toolbar, Typography, FormControlLabel, Checkbox, CircularProgress } from '@material-ui/core';
+import { appStepState, saveInProgressState, useStorageSettingState } from '../store/appState';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { AppStep } from '../types';
 import { loadedProjectState } from '../store/project';
 
@@ -9,6 +9,7 @@ export default function TopAppBar() {
   const [useStorageSettingValue, setUseStorageSetting] = useRecoilState(useStorageSettingState);
   const [appStep, setAppStepState] = useRecoilState(appStepState);
   const setLoadedProjectState = useSetRecoilState(loadedProjectState);
+  const saveInProgress = useRecoilValue(saveInProgressState);
 
   const onProjectsButtonClicked = () => {
     if( appStep !== AppStep.projectList ) {
@@ -22,7 +23,8 @@ export default function TopAppBar() {
       <Toolbar>
         <Typography variant="h6">Bingo Builder</Typography>
         <Divider orientation="vertical" flexItem style={{ marginLeft: '1em', marginRight: '1em' }} />
-        <Button onClick={onProjectsButtonClicked} color="inherit">Projects</Button>
+        { saveInProgress ? <CircularProgress size="1em" color="inherit" /> : null}
+        <Button disabled={saveInProgress} onClick={onProjectsButtonClicked} color="inherit">Projects</Button>
         <FormControlLabel
           control={
             <Checkbox

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { AppBar, Button, Divider, Toolbar, Typography, CircularProgress } from '@material-ui/core';
 import { useTheme } from '@material-ui/core/styles';
 import { appStepState, saveInProgressState } from '../store/appState';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { AppStep } from '../types';
 import { loadedProjectState } from '../store/project';
+import News from './News';
 
 export default function TopAppBar() {
   const theme = useTheme();
   const [appStep, setAppStepState] = useRecoilState(appStepState);
   const [loadedProject, setLoadedProjectState] = useRecoilState(loadedProjectState);
   const saveInProgress = useRecoilValue(saveInProgressState);
+  const [showNews, setShowNews] = useState(false);
 
   const onProjectsButtonClicked = () => {
     if( appStep !== AppStep.projectList ) {
@@ -51,6 +53,8 @@ export default function TopAppBar() {
         >Projects</Button>
         {loadedProject ? <Typography style={{ marginLeft: '0.5em', marginRight: '0.5em' }}>/</Typography> : null}
         <LoadedProjectLink />
+        <Button color="inherit" style={{marginLeft: "auto" }} onClick={() => setShowNews(true)}>What's new</Button>
+        <News open={showNews} onClose={() => setShowNews(false)} />
       </Toolbar>
     </AppBar>
   );

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -34,7 +34,7 @@ export default function TopAppBar() {
           backgroundColor: theme.palette.primary.dark
         }}
       >
-        {loadedProject.id}
+        {isSmall ? loadedProject.id.split('-')[0]+"..." : loadedProject.id}
       </Button>
     )
   }

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, FormControlLabel, Checkbox } from '@material-ui/core';
+import { useStorageSettingState } from '../store/appState';
+import { useRecoilState } from 'recoil';
+
+export default function TopAppBar() {
+  const [useStorageSettingValue, setUseStorageSetting] = useRecoilState(useStorageSettingState);
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6">Bingo Builder</Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={useStorageSettingValue}
+              onChange={ e => setUseStorageSetting(e.target.checked)}
+              name="useStorageSetting"
+            />
+          }
+          label="Use Storage"
+        />
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/src/lipsumSeed.ts
+++ b/src/lipsumSeed.ts
@@ -1,3 +1,5 @@
+import { getRandomIntInclusive } from './utils/random';
+
 const seed = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mattis fermentum semper. Sed sit amet egestas mauris, eu tincidunt libero. In in erat vitae lectus venenatis sollicitudin. Nullam pellentesque tellus a magna ultricies, ac tempor leo ultrices. Ut sit amet nibh iaculis justo lobortis finibus bibendum sit amet tellus. In id bibendum massa. Proin quis consectetur diam. Ut porttitor tortor a orci vestibulum congue eu ut ipsum. Integer egestas a arcu sed iaculis. Nullam lacinia euismod ligula ac sagittis. Nullam et erat sed nisi placerat consequat ut quis erat. Ut at purus cursus, suscipit lacus in, aliquam arcu.
 
@@ -14,5 +16,9 @@ Donec pulvinar metus eget pulvinar laoreet. Pellentesque sagittis molestie torto
 Nulla facilisi. Vivamus commodo tortor massa, et ullamcorper felis aliquam luctus. Curabitur placerat auctor luctus. Morbi eros enim, viverra sed tristique vel, cursus quis nulla. Sed imperdiet laoreet ultricies. Quisque ac iaculis lorem, eu maximus odio. In hac habitasse platea dictumst. Praesent sodales nibh nisi, ac elementum dolor interdum a. Aliquam.
 `;
 
-const words = seed.replace(/[^\d\w\s]/g, '').replace(/\s/g, ' ').split(/\s/).filter(word => word);
-export default words;
+export const words = seed.replace(/[^\d\w\s]/g, '').replace(/\s/g, ' ').split(/\s/).filter(word => word);
+
+export const getSeedLines = (numLines: number) => new Array(numLines).fill("").map(() => {
+  const numberOfWords = getRandomIntInclusive(1, 8);
+  return new Array(numberOfWords).fill("").map(() => words[getRandomIntInclusive(0, words.length - 1)]).join(' ');
+}).join("\n");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { RecoilRoot } from 'recoil'
+import { ThemeProvider } from '@material-ui/core/styles';
 import './index.css'
 import App from './App'
+import './App.css'
+import appTheme from './appTheme';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <RecoilRoot>
+      <ThemeProvider theme={appTheme}>
+        <App />
+      </ThemeProvider>
+    </RecoilRoot>
   </React.StrictMode>,
   document.getElementById('root')
 )

--- a/src/steps/InputStep.tsx
+++ b/src/steps/InputStep.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent, useEffect, useState, useRef } from 'react'
-import { Button, Box, Container, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, TextField, Typography } from '@material-ui/core'
+import { Button, Box, Container, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, TextField, CircularProgress } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles';
-import { getSeedLines } from '../lipsumSeed';
 
 import { FreeSpaceSetting, InputStepOutput, Project } from '../types';
 import BingoInput from '../components/BingoInput';
@@ -27,6 +26,7 @@ export default function InputStep({ onComplete }: Props) {
   const [numHardLinesError, setNumHardLinesError] = useState("")
   const [freeSpaceSetting, setFreeSpaceSetting] = useState(FreeSpaceSetting.center)
   const [currentTimeoutId, setCurrentTimeoutId] = useState<number>(0);
+  const [saveInProgress, setSaveInProgress] = useState(false)
 
   const getCleanedLines = (rawLines: string[]) => rawLines.map(line => line.trim()).filter(l => l);
   const cleanedEasyLines = getCleanedLines(easyLines);
@@ -88,6 +88,7 @@ export default function InputStep({ onComplete }: Props) {
     } catch (e) {
       console.error("Error saving updated project", e);
     }
+    setSaveInProgress(false);
   }
   
   const saveProjectDebounced = () => {
@@ -96,6 +97,7 @@ export default function InputStep({ onComplete }: Props) {
       saveProject();
     }, 1000);
     setCurrentTimeoutId(newTimeoutId);
+    setSaveInProgress(true);
   }
 
   useEffect(() => {
@@ -109,7 +111,11 @@ export default function InputStep({ onComplete }: Props) {
   }, [
     easyLines,
     mediumLines,
-    hardLines
+    hardLines,
+    numEasyLinesSetting,
+    numMediumLinesSetting,
+    numHardLinesSetting,
+    freeSpaceSetting
   ])
 
   const fewerLinesThanRequired = 
@@ -187,9 +193,10 @@ export default function InputStep({ onComplete }: Props) {
           variant="contained"
           color="primary"
           onClick={onNextClick}
-          disabled={totalSettingsCount !== 25}
+          disabled={totalSettingsCount !== 25 || saveInProgress}
         >
           Next
+          { saveInProgress ? (<CircularProgress style={{marginLeft: '0.5em'}} size="1em" />): null }
         </Button>
       </Box>
     </Container>

--- a/src/steps/InputStep.tsx
+++ b/src/steps/InputStep.tsx
@@ -148,6 +148,7 @@ export default function InputStep() {
     try {
       await deleteProject(loadedProject.id);
       setAppStep(AppStep.projectList);
+      setLoadedProject(null);
     } catch (e) {
       console.error("Error deleting project");
     }

--- a/src/steps/InputStep.tsx
+++ b/src/steps/InputStep.tsx
@@ -1,25 +1,23 @@
 import React, { MouseEvent, useState } from 'react'
 import { Button, Box, Container, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, TextField, Typography } from '@material-ui/core'
-import { makeStyles, useTheme } from '@material-ui/core/styles';
-import lineSeedWords from '../lipsumSeed';
-import { getRandomIntInclusive } from '../utils/random';
+import { useTheme } from '@material-ui/core/styles';
+import { getSeedLines } from '../lipsumSeed';
+
 import { FreeSpaceSetting, InputStepOutput } from '../types';
 import BingoInput from '../components/BingoInput';
+import { useRecoilState } from 'recoil';
+import { loadedProjectState } from '../store/project';
 
 type Props = {
   onComplete: (output: InputStepOutput) => void;
 }
 
-const lineSeed = (numLines: number) => new Array(numLines).fill("").map(() => {
-  const numberOfWords = getRandomIntInclusive(1, 8);
-  return new Array(numberOfWords).fill("").map(() => lineSeedWords[getRandomIntInclusive(0, lineSeedWords.length - 1)]).join(' ');
-}).join("\n");
-
 export default function InputStep({ onComplete }: Props) {
+  const [loadedProject, setLoadedProject] = useRecoilState(loadedProjectState);
   const theme = useTheme();
-  const [easyLines, setEasyLines] = useState(lineSeed(20))
-  const [mediumLines, setMediumLines] = useState(lineSeed(10))
-  const [hardLines, setHardLines] = useState(lineSeed(5))
+  const [easyLines, setEasyLines] = useState(getSeedLines(20))
+  const [mediumLines, setMediumLines] = useState(getSeedLines(10))
+  const [hardLines, setHardLines] = useState(getSeedLines(5))
   const [numEasyLinesSetting, setNumEasyLinesSetting] = useState(12)
   const [numMediumLinesSetting, setNumMediumLinesSetting] = useState(9)
   const [numHardLinesSetting, setNumHardLinesSetting] = useState(3)

--- a/src/steps/InputStep.tsx
+++ b/src/steps/InputStep.tsx
@@ -74,18 +74,15 @@ export default function InputStep({ onComplete }: Props) {
   return (
     <Container>
       <Box className="intro" marginTop={2}>
-        <h1>Bingo Builder</h1>
-        <Box>
-          <h2>Instructions</h2>
-          <p>
-            Please enter as many bingo square entries as you like below, one per line. Empty lines will be ignored.
-          </p>
-          <p>
-            At this time, the bingo board is limited to 5x5 (25) squares. Each board will use a random selection of 
-            25 of the lines below. If fewer than 25 lines are provided, empty spaces will be used to fill the rest
-            of the squares.
-          </p>
-        </Box>
+        <h2>Instructions</h2>
+        <p>
+          Please enter as many bingo square entries as you like below, one per line. Empty lines will be ignored.
+        </p>
+        <p>
+          At this time, the bingo board is limited to 5x5 (25) squares. Each board will use a random selection of 
+          25 of the lines below. If fewer than 25 lines are provided, empty spaces will be used to fill the rest
+          of the squares.
+        </p>
       </Box>
       <h2>Input Lines</h2>
       <BingoInput label="Easy" onChange={(lines: string) => setEasyLines(lines)} lines={easyLines} />

--- a/src/steps/InputStep.tsx
+++ b/src/steps/InputStep.tsx
@@ -81,13 +81,13 @@ export default function InputStep() {
       console.error("Error saving updated project", e);
       if( !failSilently ) throw e;
     }
-    setSaveInProgress(false);
   }
   
   const saveProjectDebounced = () => {
     if( currentTimeoutId ) clearTimeout(currentTimeoutId);
-    const newTimeoutId = setTimeout(() => {
-      saveProject();
+    const newTimeoutId = setTimeout(async () => {
+      await saveProject();
+      setSaveInProgress(false);
     }, 1000);
     setCurrentTimeoutId(newTimeoutId);
     setSaveInProgress(true);
@@ -110,6 +110,16 @@ export default function InputStep() {
     numHardLinesSetting,
     freeSpaceSetting
   ])
+
+  //Force a save on unmount
+  useEffect(() => {
+    return () => {
+      saveProject(false).catch(e => {
+        setSaveInProgress(false);
+        console.error("Error saving project on InputStep unmount", e);
+      });
+    }
+  }, [])
 
   const fewerLinesThanRequired = 
     cleanedEasyLines.length < numEasyLinesSetting ||

--- a/src/steps/ProjectList.tsx
+++ b/src/steps/ProjectList.tsx
@@ -61,11 +61,9 @@ export default function ProjectList() {
     }
   }
 
-  return (
-    <Container>
-      <Box marginTop={2}>
-        <Button variant="contained" color="primary" onClick={handleNewProjectClick}>Create New Project</Button>
-      </Box>
+  const ProjectListBox = () => {
+    if( !listItemProjects.length ) return null;
+    return (
       <Box marginTop={2}>
         <Typography variant="h4">Projects</Typography>
         <Divider />
@@ -77,6 +75,15 @@ export default function ProjectList() {
           ))}
         </List>
       </Box>
+    )
+  }
+
+  return (
+    <Container>
+      <Box marginTop={2}>
+        <Button variant="contained" color="primary" onClick={handleNewProjectClick}>Create New Project</Button>
+      </Box>
+      <ProjectListBox />
     </Container>
   )
 }

--- a/src/steps/ProjectList.tsx
+++ b/src/steps/ProjectList.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button, Container } from '@material-ui/core';
+import { Project, NewProject, FreeSpaceSetting, AppStep } from '../types';
+import { getSeedLines } from '../lipsumSeed';
+import { loadedProjectState, saveProject } from '../store/project';
+import { useSetRecoilState } from 'recoil';
+import { appStepState } from '../store/appState';
+
+export default function ProjectList() {
+  const setLoadedProject = useSetRecoilState(loadedProjectState);
+  const setAppStep = useSetRecoilState(appStepState);
+
+  const handleNewProjectClick = async () => {
+    const newProject: NewProject = {
+      name: 'New Project',
+      lines: {
+        easy: getSeedLines(20).split(/[\n\r]/g),
+        medium: getSeedLines(10).split(/[\n\r]/g),
+        hard: getSeedLines(5).split(/[\n\r]/g),
+      },
+      settings: {
+        freeSpace: FreeSpaceSetting.center,
+        easy: 12,
+        medium: 9,
+        hard: 3
+      }
+    }
+    
+    let savedProject: Project;
+    try {
+      savedProject = await saveProject(newProject);
+    } catch (e) {
+      console.error("Error saving newly created project", e);
+      return;
+    }
+    
+    setLoadedProject(savedProject);
+
+    setAppStep(AppStep.input);
+  }
+
+  return (
+    <Container>
+      <Button variant="contained" color="primary" onClick={handleNewProjectClick}>Create New Project</Button>
+    </Container>
+  )
+}

--- a/src/steps/ProjectList.tsx
+++ b/src/steps/ProjectList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Container, List, ListItem, ListItemText } from '@material-ui/core';
+import { Box, Button, Container, Divider, List, ListItem, ListItemText, Typography } from '@material-ui/core';
 import { Project, NewProject, FreeSpaceSetting, AppStep, ListItemProject } from '../types';
 import { getSeedLines } from '../lipsumSeed';
 import { getProject, listProjects, loadedProjectState, saveProject } from '../store/project';
@@ -63,14 +63,20 @@ export default function ProjectList() {
 
   return (
     <Container>
-      <Button variant="contained" color="primary" onClick={handleNewProjectClick}>Create New Project</Button>
-      <List aria-label="projects">
-        {listItemProjects.map(project => (
-          <ListItem button key={project.id} onClick={() => onProjectClick(project.id)}>
-            <ListItemText primary={project.name} secondary={project.id} />
-          </ListItem>
-        ))}
-      </List>
+      <Box marginTop={2}>
+        <Button variant="contained" color="primary" onClick={handleNewProjectClick}>Create New Project</Button>
+      </Box>
+      <Box marginTop={2}>
+        <Typography variant="h4">Projects</Typography>
+        <Divider />
+        <List aria-label="projects">
+          {listItemProjects.map(project => (
+            <ListItem button key={project.id} onClick={() => onProjectClick(project.id)}>
+              <ListItemText primary={project.name} secondary={project.id} />
+            </ListItem>
+          ))}
+        </List>
+      </Box>
     </Container>
   )
 }

--- a/src/steps/RenderStep.tsx
+++ b/src/steps/RenderStep.tsx
@@ -1,15 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { Box, LinearProgress, Container, Backdrop, Paper } from '@material-ui/core'
+import { Box, LinearProgress, Container, Backdrop, Paper, Typography, CircularProgress } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import { waitUntil } from '../utils/timeout';
 import { gridStyles } from './styles';
 import { BaseFontSize, SingleBoxSizePx } from '../utils/constants';
-import { LinesByDifficulty, LineAndStyle, LineAndStyleByDifficulty, DifficultyKey } from '../types';
-
-type Props = {
-  linesToRender: LinesByDifficulty,
-  onComplete: (linesAndStyles: LineAndStyleByDifficulty) => void;
-}
+import { LineAndStyle, LineAndStyleByDifficulty, DifficultyKey, Project } from '../types';
+import { loadedProjectState } from '../store/project';
+import { useRecoilValue } from 'recoil';
 
 const useStyles = makeStyles({
   percent: {
@@ -18,7 +15,11 @@ const useStyles = makeStyles({
   }
 })
 
-export default function RenderStep({ linesToRender, onComplete }: Props) {
+type Props = {
+  onComplete: (linesAndStyles: LineAndStyleByDifficulty) => void;
+}
+
+export default function RenderStep({ onComplete }: Props) {
   const gridClasses = gridStyles();
   const [lineFontSizes, setLineFontSizes] = useState({
     easy: [] as number[],
@@ -34,18 +35,29 @@ export default function RenderStep({ linesToRender, onComplete }: Props) {
   const renderedTextSpan = useRef<HTMLSpanElement>(null);
   const styles = useStyles();
   const [openBackdrop, setOpenBackdrop] = useState(true);
-  const incrementalProgress = 100 / (linesToRender.easy.length + linesToRender.medium.length + linesToRender.hard.length);
+  const loadedProject = useRecoilValue(loadedProjectState);
+  if( !loadedProject ) {
+    return (
+      <Container>
+        <Typography color="error" variant="h2">Error</Typography>
+        <p>
+          No project was loaded.
+        </p>
+      </Container>
+    )
+  }
+  const incrementalProgress = 100 / (loadedProject.lines.easy.length + loadedProject.lines.medium.length + loadedProject.lines.hard.length);
 
   useEffect(() => {
     (async () => {
-      await waitUntil(() => renderedTextSpan.current!.innerText.trim() === linesToRender[renderState.currentDifficulty][renderState.currentLine]);
+      await waitUntil(() => renderedTextSpan.current!.innerText.trim() === loadedProject.lines[renderState.currentDifficulty][renderState.currentLine]);
       if ((renderedTextSpan.current!.offsetHeight > SingleBoxSizePx.h * .95 || renderedTextSpan.current!.offsetWidth > SingleBoxSizePx.w * .95) && renderState.currentLineFontSize > 6) {
         updateRenderState({
           ...renderState,
           currentLineFontSize: renderState.currentLineFontSize - 1
         })
       }
-      else if (renderState.currentLine === linesToRender[renderState.currentDifficulty].length - 1) {
+      else if (renderState.currentLine === loadedProject.lines[renderState.currentDifficulty].length - 1) {
         if( renderState.currentDifficulty !== "hard" ) {
           setLineFontSizes({
             ...lineFontSizes,
@@ -72,10 +84,11 @@ export default function RenderStep({ linesToRender, onComplete }: Props) {
           setTimeout(() => {
             setOpenBackdrop(false);
             setTimeout(() => {
+              // TODO: Go to complete step
               onComplete({
-                easy: toLineAndStyles(linesToRender.easy, 'easy'),
-                medium: toLineAndStyles(linesToRender.medium, 'medium'),
-                hard: toLineAndStyles(linesToRender.hard, 'hard')
+                easy: toLineAndStyles(loadedProject.lines.easy, 'easy'),
+                medium: toLineAndStyles(loadedProject.lines.medium, 'medium'),
+                hard: toLineAndStyles(loadedProject.lines.hard, 'hard')
               })
             }, 200);
           }, 500)
@@ -103,7 +116,7 @@ export default function RenderStep({ linesToRender, onComplete }: Props) {
           <span style={{
             fontSize: `${renderState.currentLineFontSize}px`
           }} ref={renderedTextSpan}>
-            {linesToRender[renderState.currentDifficulty][renderState.currentLine]}
+            {loadedProject.lines[renderState.currentDifficulty][renderState.currentLine]}
           </span>
         </Box>
       </Box>}

--- a/src/steps/RenderStep.tsx
+++ b/src/steps/RenderStep.tsx
@@ -8,12 +8,15 @@ import { LineAndStyle, LineAndStyleByDifficulty, DifficultyKey, Project } from '
 import { loadedProjectState } from '../store/project';
 import { useRecoilValue } from 'recoil';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   percent: {
     fontSize: '2rem',
     textAlign: 'center'
+  },
+  backdrop: {
+    zIndex: theme.zIndex.drawer + 1
   }
-})
+}))
 
 type Props = {
   onComplete: (linesAndStyles: LineAndStyleByDifficulty) => void;
@@ -120,7 +123,7 @@ export default function RenderStep({ onComplete }: Props) {
           </span>
         </Box>
       </Box>}
-      <Backdrop open={openBackdrop}>
+      <Backdrop open={openBackdrop} className={styles.backdrop}>
         <Paper elevation={1}>
           <Box margin={2}>
             <h2>Rendering</h2>

--- a/src/steps/RenderStep.tsx
+++ b/src/steps/RenderStep.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { Box, LinearProgress, Container, Backdrop, Paper, Typography, CircularProgress } from '@material-ui/core'
+import { Box, LinearProgress, Container, Backdrop, Paper, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import { waitUntil } from '../utils/timeout';
 import { gridStyles } from './styles';
 import { BaseFontSize, SingleBoxSizePx } from '../utils/constants';
-import { LineAndStyle, LineAndStyleByDifficulty, DifficultyKey, Project } from '../types';
+import { LineAndStyle, LineAndStyleByDifficulty, DifficultyKey } from '../types';
 import { loadedProjectState } from '../store/project';
 import { useRecoilValue } from 'recoil';
 

--- a/src/store/appState.ts
+++ b/src/store/appState.ts
@@ -1,11 +1,6 @@
 import { atom } from "recoil";
 import { AppStep } from "../types";
 
-export const useStorageSettingState = atom({
-  key: 'useStorageSetting',
-  default: true
-});
-
 export const appStepState = atom({
   key: 'appStep',
   default: AppStep.projectList

--- a/src/store/appState.ts
+++ b/src/store/appState.ts
@@ -9,4 +9,9 @@ export const useStorageSettingState = atom({
 export const appStepState = atom({
   key: 'appStep',
   default: AppStep.projectList
+});
+
+export const saveInProgressState = atom({
+  key: 'saveInProgress',
+  default: false
 })

--- a/src/store/appState.ts
+++ b/src/store/appState.ts
@@ -1,0 +1,12 @@
+import { atom } from "recoil";
+import { AppStep } from "../types";
+
+export const useStorageSettingState = atom({
+  key: 'useStorageSetting',
+  default: true
+});
+
+export const appStepState = atom({
+  key: 'appStep',
+  default: AppStep.projectList
+})

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -24,10 +24,6 @@ export async function getProject(projectId: string): Promise<Project | null> {
   return projectJson ? JSON.parse(projectJson) : null;
 }
 
-function isNotNullOrUndefined<T extends Object>(input: null | undefined | T): input is T {
-  return input != null;
-}
-
 export async function listProjects(): Promise<ListItemProject[]> {
   const projectKeyRegex = /^projects\/[\w\-]{36}$/i;
   const projectIds = Object.keys(localStorage).filter(key => projectKeyRegex.test(key)).map(path => path.slice(-36));

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 import { v4 as uuidv4 } from 'uuid';
-import { Project, NewProject } from '../types'
+import { Project, NewProject, ListItemProject } from '../types'
 
 export const loadedProjectState = atom<Project | null>({
   key: 'useStorage',
@@ -22,4 +22,27 @@ export async function getProject(projectId: string): Promise<Project | null> {
   const projectKey = `projects/${projectId}`;
   const projectJson = localStorage.getItem(projectKey);
   return projectJson ? JSON.parse(projectJson) : null;
+}
+
+function isNotNullOrUndefined<T extends Object>(input: null | undefined | T): input is T {
+  return input != null;
+}
+
+export async function listProjects(): Promise<ListItemProject[]> {
+  const projectKeyRegex = /^projects\/[\w\-]{36}$/i;
+  const projectIds = Object.keys(localStorage).filter(key => projectKeyRegex.test(key)).map(path => path.slice(-36));
+  const projects = projectIds.map(projectId => {
+    const storedItem = localStorage.getItem(`projects/${projectId}`);
+    if( !storedItem ) return null;
+    try {
+      const parsedProject = JSON.parse(storedItem) as Project;
+      return {
+        id: parsedProject.id,
+        name: parsedProject.name
+      }
+    } catch (e) {
+      return null;
+    }
+  }).filter((f): f is Project => !!f); //Typescript is so dumb sometimes
+  return projects;
 }

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,0 +1,25 @@
+import { atom } from "recoil";
+import { v4 as uuidv4 } from 'uuid';
+import { Project, NewProject } from '../types'
+
+export const loadedProjectState = atom<Project | null>({
+  key: 'useStorage',
+  default: null
+})
+
+export async function saveProject(unsavedProject: Project | NewProject): Promise<Project> {
+  const projectId = unsavedProject.id || uuidv4();
+  const projectKey = `projects/${projectId}`;
+  const newProject: Project = {
+    ...unsavedProject,
+    id: projectId
+  };
+  localStorage.setItem(projectKey, JSON.stringify(newProject));
+  return newProject;
+}
+
+export async function getProject(projectId: string): Promise<Project | null> {
+  const projectKey = `projects/${projectId}`;
+  const projectJson = localStorage.getItem(projectKey);
+  return projectJson ? JSON.parse(projectJson) : null;
+}

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -14,7 +14,11 @@ export async function saveProject(unsavedProject: Project | NewProject): Promise
     ...unsavedProject,
     id: projectId
   };
-  localStorage.setItem(projectKey, JSON.stringify(newProject));
+  try {
+    localStorage.setItem(projectKey, JSON.stringify(newProject));
+  } catch (e) {
+    console.error(`LocalStorage setItem failed for ${projectId}, storage may be full`);
+  }
   return newProject;
 }
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -46,3 +46,8 @@ export async function listProjects(): Promise<ListItemProject[]> {
   }).filter((f): f is Project => !!f); //Typescript is so dumb sometimes
   return projects;
 }
+
+export async function deleteProject(projectId: string): Promise<void> {
+  const projectKey = `projects/${projectId}`;
+  localStorage.removeItem(projectKey);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,16 @@ export type Settings = {
 }
 
 export type InputStepOutput = {
-  lines: LinesByDifficulty,
-  settings: Settings
+  lines: LinesByDifficulty;
+  settings: Settings;
+};
+
+export type Project = {
+  lines: LinesByDifficulty;
+  settings: Settings;
+  name: string;
+};
+
+export type AppStore = {
+  projects: Project;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,11 @@ export type Project = {
   settings: Settings;
 };
 
+export type ListItemProject = {
+  id: string;
+  name: string;
+}
+
 export type AppStore = {
   projects: Project;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,13 @@ export enum FreeSpaceSetting {
   random = "random"
 }
 
+export enum AppStep {
+  projectList,
+  input,
+  render,
+  output
+}
+
 export type DifficultyKey = 'easy' | 'medium' | 'hard';
 
 export type LinesByDifficulty = {
@@ -35,10 +42,18 @@ export type InputStepOutput = {
   settings: Settings;
 };
 
-export type Project = {
+export type NewProject = {
+  id?: string;
+  name: string;
   lines: LinesByDifficulty;
   settings: Settings;
+}
+
+export type Project = {
+  id: string;
   name: string;
+  lines: LinesByDifficulty;
+  settings: Settings;
 };
 
 export type AppStore = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import { defineConfig, UserConfigExport } from 'vite'
+import reactPlugin from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [reactRefresh()]
+export default defineConfig(({command, mode }) => {
+  let config: UserConfigExport = {
+    plugins: [reactPlugin()],
+    build: {}
+  }
+  if( command === 'serve' || mode === 'development' ) {
+    config.build.sourcemap = true;
+  }
+
+  return config;
 })


### PR DESCRIPTION
This PR adds the ability for users to save bingo projects in LocalStorage.

The concept of a "Project" has been created, and will contain a name and ID in addition to the existing lines and settings. Users will now have to select a project in order to access the bingo flow they are used to. If the user has no projects, they can create a new project that will be immediately saved.

Navigation now generally waits for any in-progress saves to complete, but of course we can't stop the user from closing their tab or something. Changes are debounced for 1000ms unless the user initiates navigation, in which case we immediately try to save.

Behind the scenes, I've added Recoil as a state management library, and created a basic project store to abstract away the storage methods. I should be able to replace the storage methods with remote storage in the future quite easily.

There is also now news that I can update if I remember.

Last, I updated all the dependencies I could, ensuring we get past the recent `minimist` vulnerability as well.